### PR TITLE
feat: reducing list item padding vertically

### DIFF
--- a/nerdlets/nerdpack-layout-standard-nerdlet/styles.scss
+++ b/nerdlets/nerdpack-layout-standard-nerdlet/styles.scss
@@ -63,7 +63,7 @@
 }
 
 .sidebar-list-item {
-  padding: 12px 16px;
+  padding: 8px 16px;
   list-style-type: none;
   color: #2a3434;
   font-size: 12px;


### PR DESCRIPTION
Reduced the vertical padding of list items in the left sidebar so that you can see more of them at a glance. I think that will be helpful for people who actually use this template.

Super simple and straightforward, but I wanted to see it done.