### PR TITLE
chore: update minimist dependancy

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1580,8 +1580,8 @@
       }
     },
     "minimist": {
-      "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.2.1.tgz",
       "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
       "dev": true
     },
@@ -1591,7 +1591,7 @@
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
       "dev": true,
       "requires": {
-        "minimist": "0.0.8"
+        "minimist": "0.2.1"
       }
     },
     "ms": {


### PR DESCRIPTION
Dependabot is complaining about `minimist` not being up to date, so I'm bumping the version here.